### PR TITLE
Share port 80 for the WordPress instance

### DIFF
--- a/compose-sandbox.yml
+++ b/compose-sandbox.yml
@@ -21,7 +21,7 @@ services:
       - .:/var/www/html/wp-content/ # takes files from the local root and places them in the /var/www/html/wp-content directory of the container
       - plugin-data:/var/www/html/wp-content/plugins/WSUWP-Plugin-iDonate
     ports:
-      - "8000:80"
+      - "80:80"
     restart: always
     environment:
       WORDPRESS_DB_HOST: db:3306


### PR DESCRIPTION
Using a different port (like 8000) breaks the WordPress installation when deployed to a cloud service